### PR TITLE
Pcap api additions

### DIFF
--- a/pcap.go
+++ b/pcap.go
@@ -55,14 +55,14 @@ func (p *Pcap) Geterror() error     { return &pcapError{C.GoString(C.pcap_geterr
 func (p *Pcap) Next() (pkt *Packet) { rv, _ := p.NextEx(); return rv }
 
 func Create(device string) (handle *Pcap, err error) {
-    var buf *C.char
+	var buf *C.char
 	buf = (*C.char)(C.calloc(ERRBUF_SIZE, 1))
 	h := new(Pcap)
 
 	dev := C.CString(device)
 	defer C.free(unsafe.Pointer(dev))
 
-    h.cptr = C.pcap_create(dev, buf)
+	h.cptr = C.pcap_create(dev, buf)
 	if nil == h.cptr {
 		handle = nil
 		err = &pcapError{C.GoString(buf)}
@@ -85,18 +85,18 @@ func (p *Pcap) SetBufferSize(sz int32) error {
 //  If arg p is non-zero promiscuous mode will be set on capture handle when it is activated.
 func (p *Pcap) SetPromisc(promisc bool) error {
 	var pro int32
-    if promisc {
-        pro = 1
-    }
+	if promisc {
+		pro = 1
+	}
 
-    if C.pcap_set_promisc(p.cptr, C.int(pro)) != 0 {
+	if C.pcap_set_promisc(p.cptr, C.int(pro)) != 0 {
 		return p.Geterror()
 	}
 	return nil
 }
 
 func (p *Pcap) SetSnapLen(s int32) error {
-    if C.pcap_set_snaplen(p.cptr, C.int(s)) != 0 {
+	if C.pcap_set_snaplen(p.cptr, C.int(s)) != 0 {
 		return p.Geterror()
 	}
 	return nil
@@ -104,7 +104,7 @@ func (p *Pcap) SetSnapLen(s int32) error {
 
 // Set read timeout (milliseconds) that will be used on a capture handle when it is activated.
 func (p *Pcap) SetReadTimeout(toMs int32) error {
-    if C.pcap_set_timeout(p.cptr, C.int(toMs)) != 0 {
+	if C.pcap_set_timeout(p.cptr, C.int(toMs)) != 0 {
 		return p.Geterror()
 	}
 	return nil

--- a/pcap_test.go
+++ b/pcap_test.go
@@ -1,10 +1,10 @@
 package pcap
 
 import (
+	"fmt"
+	"net"
 	"testing"
-    "fmt"
-    "net"
-    "time"
+	"time"
 )
 
 func TestPcap(t *testing.T) {
@@ -16,80 +16,80 @@ func TestPcap(t *testing.T) {
 	_ = err
 }
 
-type pcapNewHandleFunc func (intf string, filter string, readTo int32) (h *Pcap, err error)
+type pcapNewHandleFunc func(intf string, filter string, readTo int32) (h *Pcap, err error)
 
 func testPcapHandle(t *testing.T, newHandle pcapNewHandleFunc) {
-    port := 54321
-    h, err := newHandle("lo", fmt.Sprintf("udp dst port %d", port), 2000)
-    if h == nil || err != nil {
-        if h != nil {
-            h.Close()
-        }
-        t.Fatalf("Failed to create/init pcap handle err:%s", err)
-    }
+	port := 54321
+	h, err := newHandle("lo", fmt.Sprintf("udp dst port %d", port), 2000)
+	if h == nil || err != nil {
+		if h != nil {
+			h.Close()
+		}
+		t.Fatalf("Failed to create/init pcap handle err:%s", err)
+	}
 
-    numPkts := 5
-    go udpSvr(port, numPkts, t)
-    go udpClient(port, numPkts, 1 * time.Second, t)
+	numPkts := 5
+	go udpSvr(port, numPkts, t)
+	go udpClient(port, numPkts, 1*time.Second, t)
 
-    pktsRecvd := 0
-    for pkt := h.Next(); pkt != nil; pkt = h.Next() {
-        pkt.Decode()
-        t.Logf("Packet:%s dataLen:%d", pkt, len(pkt.Payload))
-        pktsRecvd += 1
-    }
+	pktsRecvd := 0
+	for pkt := h.Next(); pkt != nil; pkt = h.Next() {
+		pkt.Decode()
+		t.Logf("Packet:%s dataLen:%d", pkt, len(pkt.Payload))
+		pktsRecvd += 1
+	}
 
-    if pktsRecvd != numPkts {
-        t.Fatalf("Capture failed pkts-send:%d, pkts-recvd:%d", numPkts, pktsRecvd)
-    }
+	if pktsRecvd != numPkts {
+		t.Fatalf("Capture failed pkts-send:%d, pkts-recvd:%d", numPkts, pktsRecvd)
+	}
 
-    t.Logf("Successfully captured %d packets", numPkts)
+	t.Logf("Successfully captured %d packets", numPkts)
 }
 
 func TestPcapCreate(t *testing.T) {
-    testPcapHandle(t, pcapCreate)
+	testPcapHandle(t, pcapCreate)
 }
 
 func TestPcapOpenLive(t *testing.T) {
-    testPcapHandle(t, pcapOpenLive)
+	testPcapHandle(t, pcapOpenLive)
 }
 
 func pcapCreate(intf string, filter string, readTo int32) (h *Pcap, err error) {
-    h, err = Create("lo")
+	h, err = Create("lo")
 	if h == nil || err != nil {
 		return
 	}
 
 	err = h.SetSnapLen(65535)
-    if err != nil {
-        return
-    }
-
-    err = h.SetReadTimeout(readTo)
-    if err != nil {
-        return
-    }
-
-    err = h.SetBufferSize(3 * 1024 * 1024)
-    if err != nil {
-        return
-    }
-
-    err = h.Activate()
 	if err != nil {
 		return
 	}
 
-    err = h.SetFilter(filter)
+	err = h.SetReadTimeout(readTo)
 	if err != nil {
 		return
 	}
 
-    return
+	err = h.SetBufferSize(3 * 1024 * 1024)
+	if err != nil {
+		return
+	}
+
+	err = h.Activate()
+	if err != nil {
+		return
+	}
+
+	err = h.SetFilter(filter)
+	if err != nil {
+		return
+	}
+
+	return
 }
 
 func pcapOpenLive(intf string, filter string, readTo int32) (h *Pcap, err error) {
-    h, err = OpenLive(intf, 65535, true, readTo)
+	h, err = OpenLive(intf, 65535, true, readTo)
 	if h == nil || err != nil {
 		return
 	}
@@ -99,13 +99,13 @@ func pcapOpenLive(intf string, filter string, readTo int32) (h *Pcap, err error)
 		return
 	}
 
-    return
+	return
 }
 
 // Udp client which sends a fixed num of packets to given port after a fixed delay.
-// Delay ensures that capture code is ready to recv packets. 
+// Delay ensures that capture code is ready to recv packets.
 func udpClient(port int, numPkts int, wait time.Duration, t *testing.T) {
-    time.Sleep(wait)
+	time.Sleep(wait)
 
 	addr, err := net.ResolveUDPAddr("udp", fmt.Sprintf("127.0.0.1:%d", port))
 	if err != nil {
@@ -119,39 +119,39 @@ func udpClient(port int, numPkts int, wait time.Duration, t *testing.T) {
 		return
 	}
 
-    t.Logf("Start packets to port:%d", port)
+	t.Logf("Start packets to port:%d", port)
 
-    pkt := []byte("hello")
-    for i := 0 ; i < numPkts; i++ {
-        if l, err := conn.Write(pkt); err != nil || l != len(pkt) {
-		    t.Logf("ERROR Failed to send packet size:%d wlen:%d err:%s", len(pkt), l, err)
-        }
-    }
+	pkt := []byte("hello")
+	for i := 0; i < numPkts; i++ {
+		if l, err := conn.Write(pkt); err != nil || l != len(pkt) {
+			t.Logf("ERROR Failed to send packet size:%d wlen:%d err:%s", len(pkt), l, err)
+		}
+	}
 
-    t.Logf("Completed sending packets to port:%d", port)
+	t.Logf("Completed sending packets to port:%d", port)
 }
 
 // Udp server which listens on a port and recvs a fixed number of packets.
 func udpSvr(port int, numPkts int, t *testing.T) {
-    addr, err := net.ResolveUDPAddr("udp", fmt.Sprintf("localhost:%d", port))
-    if err != nil {
+	addr, err := net.ResolveUDPAddr("udp", fmt.Sprintf("localhost:%d", port))
+	if err != nil {
 		t.Logf("ERROR UDP Server: failed to resolve udp addr err:%s", err)
 		return
 	}
 
-    sock, err := net.ListenUDP("udp", addr)
-    if err != nil {
+	sock, err := net.ListenUDP("udp", addr)
+	if err != nil {
 		t.Logf("ERROR UDP Server: failed to listen on port:%d err:%s", port, err)
 		return
 	}
 
-    buf := make([]byte, 10, 1024)
-    for i := 0 ; i < numPkts; i++ {
-        _, _, err := sock.ReadFromUDP(buf)
-        if err != nil {
-            t.Logf("Failed to recv packets on port:%d err:%s", port, err)
-        }
-    }
+	buf := make([]byte, 10, 1024)
+	for i := 0; i < numPkts; i++ {
+		_, _, err := sock.ReadFromUDP(buf)
+		if err != nil {
+			t.Logf("Failed to recv packets on port:%d err:%s", port, err)
+		}
+	}
 
-    sock.Close()
+	sock.Close()
 }


### PR DESCRIPTION
pcap_set_buffer_size api is required to set receive buffer size (linux default = 2 MB) . But this can be called only on handles which are not activated. On activated handles it fails with error 'can't perform  operation on activated capture'. So create and activate has to be done in 2 steps using pcap_create and pcap_activate apis.

This commit adds wrappers for following pcap apis.
- pcap_create
- pcap_activate
- pcap_set_buffer_size
- pcap_set_promisc
- pcap_timeout
- pcap_set_snaplen

It also adds unit tests to test creation and configuration of pcap handles using pcap_open_live and pcap_create apis.
'sudo go test -v' is required for these unit tests as it captures packets from 'lo' interface.
