### PR TITLE
Fix nil pointer dereference for tunnel device

### DIFF
--- a/pcap.go
+++ b/pcap.go
@@ -278,6 +278,9 @@ func findAllAddresses(addresses *_Ctype_struct_pcap_addr) (retval []IFAddress) {
 	// TODO - make it support more than IPv4 and IPv6?
 	retval = make([]IFAddress, 0, 1)
 	for curaddr := addresses; curaddr != nil; curaddr = (*_Ctype_struct_pcap_addr)(curaddr.next) {
+		if curaddr.addr == nil {
+			continue
+		}
 		var a IFAddress
 		var err error
 		if a.IP, err = sockaddrToIP((*syscall.RawSockaddr)(unsafe.Pointer(curaddr.addr))); err != nil {


### PR DESCRIPTION
Fix for a nil de-reference in FindAllDevs() for tunnel devices such as this one:

```
tun0      Link encap:UNSPEC  HWaddr 00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00  
          inet addr:46.246.47.79  P-t-P:46.246.47.79  Mask:255.255.255.0
          UP POINTOPOINT RUNNING NOARP MULTICAST  MTU:1500  Metric:1
          RX packets:3454 errors:0 dropped:0 overruns:0 frame:0
          TX packets:61188 errors:0 dropped:56249 overruns:0 carrier:0
          collisions:0 txqueuelen:100 
          RX bytes:1495075 (1.4 MiB)  TX bytes:86419971 (82.4 MiB)
```
