### PR TITLE
Changed FindAllDevs to return error object instead of string.

### DIFF
--- a/pcap.go
+++ b/pcap.go
@@ -235,18 +235,18 @@ func (p *Pcap) SetFilter(expr string) (err error) {
 }
 
 func (p *Pcap) SetDirection(direction string) (err error) {
-    var pcap_direction C.pcap_direction_t
-    if (direction == "in") {
-        pcap_direction = C.PCAP_D_IN
-    } else if (direction == "out") {
-        pcap_direction = C.PCAP_D_OUT
-    } else {
-        pcap_direction = C.PCAP_D_INOUT
-    }
-    if -1 == C.pcap_setdirection(p.cptr, pcap_direction) {
-        return p.Geterror()
-    }
-    return nil
+	var pcap_direction C.pcap_direction_t
+	if direction == "in" {
+		pcap_direction = C.PCAP_D_IN
+	} else if direction == "out" {
+		pcap_direction = C.PCAP_D_OUT
+	} else {
+		pcap_direction = C.PCAP_D_INOUT
+	}
+	if -1 == C.pcap_setdirection(p.cptr, pcap_direction) {
+		return p.Geterror()
+	}
+	return nil
 }
 
 func (p *Pcap) SetDataLink(dlt int) error {
@@ -270,14 +270,14 @@ func DatalinkValueToDescription(dlt int) string {
 	return ""
 }
 
-func FindAllDevs() (ifs []Interface, err string) {
+func FindAllDevs() (ifs []Interface, err error) {
 	var buf *C.char
 	buf = (*C.char)(C.calloc(ERRBUF_SIZE, 1))
 	defer C.free(unsafe.Pointer(buf))
 	var alldevsp *C.pcap_if_t
 
 	if -1 == C.pcap_findalldevs((**C.pcap_if_t)(&alldevsp), buf) {
-		return nil, C.GoString(buf)
+		return nil, errors.New(C.GoString(buf))
 	}
 	defer C.pcap_freealldevs((*C.pcap_if_t)(alldevsp))
 	dev := alldevsp

--- a/tools/pcaptest/pcaptest.go
+++ b/tools/pcaptest/pcaptest.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/dustin/gopcap"
+	"github.com/miekg/pcap"
 )
 
 func min(x uint32, y uint32) uint32 {
@@ -23,7 +23,6 @@ func main() {
 	flag.Parse()
 
 	var h *pcap.Pcap
-	var err string
 
 	ifs, err := pcap.FindAllDevs()
 	if len(ifs) == 0 {
@@ -56,15 +55,15 @@ func main() {
 	if *expr != "" {
 		fmt.Printf("Setting filter: %s\n", *expr)
 		err := h.SetFilter(*expr)
-		if err != "" {
+		if err != nil {
 			fmt.Printf("Warning: setting filter failed: %s\n", err)
 		}
 	}
 
 	for pkt := h.Next(); pkt != nil; pkt = h.Next() {
 		fmt.Printf("time: %d.%06d (%s) caplen: %d len: %d\nData:",
-			int64(pkt.Time.Sec), int64(pkt.Time.Usec),
-			time.Unix(int64(pkt.Time.Sec), 0).String(), int64(pkt.Caplen), int64(pkt.Len))
+			int64(pkt.Time.Second()), int64(pkt.Time.Nanosecond()),
+			time.Unix(int64(pkt.Time.Second()), 0).String(), int64(pkt.Caplen), int64(pkt.Len))
 		for i := uint32(0); i < pkt.Caplen; i++ {
 			if i%32 == 0 {
 				fmt.Printf("\n")


### PR DESCRIPTION
Minor changes to get things to build.  The majority of the changes in diff resulted from running gofmt.
- Changed FindAllDevs to return error object instead of string. 
- fixed issues in pcaptest.go
