### PR TITLE
Tcphdr Data Member not written

### DIFF
--- a/packet.go
+++ b/packet.go
@@ -159,6 +159,7 @@ func (p *Packet) decodeTcp() {
 	}
 	pkt := p.Payload
 	tcp := new(Tcphdr)
+	tcp.Data = pkt
 	tcp.SrcPort = binary.BigEndian.Uint16(pkt[0:2])
 	tcp.DestPort = binary.BigEndian.Uint16(pkt[2:4])
 	tcp.Seq = binary.BigEndian.Uint32(pkt[4:8])


### PR DESCRIPTION
`Tcphdr` Data member wasn't being set in decodeTcp. Needed for access to TCP header options