### PR TITLE
Fix compile errors on later go versions

### DIFF
--- a/packet.go
+++ b/packet.go
@@ -74,7 +74,7 @@ func (p *Packet) headerString(headers []interface{}) string {
 	if len(headers) >= 2 {
 		if addr, ok := headers[0].(addrHdr); ok {
 			if _, ok := headers[1].(addrHdr); ok {
-				return fmt.Sprintf("%s > %s IP in IP: ",
+				return fmt.Sprintf("%s > %s IP in IP: %s",
 					addr.SrcAddr(), addr.DestAddr(), p.headerString(headers[1:]))
 			}
 		}

--- a/pcap.go
+++ b/pcap.go
@@ -205,7 +205,7 @@ func (p *Pcap) NextEx() (pkt *Packet, result int32) {
 }
 
 func (p *Pcap) Getstats() (stat *Stat, err error) {
-	var cstats _Ctype_struct_pcap_stat
+	var cstats C.struct_pcap_stat
 	if -1 == C.pcap_stats(p.cptr, &cstats) {
 		return nil, p.Geterror()
 	}
@@ -218,7 +218,7 @@ func (p *Pcap) Getstats() (stat *Stat, err error) {
 }
 
 func (p *Pcap) SetFilter(expr string) (err error) {
-	var bpf _Ctype_struct_bpf_program
+	var bpf C.struct_bpf_program
 	cexpr := C.CString(expr)
 	defer C.free(unsafe.Pointer(cexpr))
 
@@ -299,10 +299,10 @@ func FindAllDevs() (ifs []Interface, err error) {
 	return
 }
 
-func findAllAddresses(addresses *_Ctype_struct_pcap_addr) (retval []IFAddress) {
+func findAllAddresses(addresses *C.struct_pcap_addr) (retval []IFAddress) {
 	// TODO - make it support more than IPv4 and IPv6?
 	retval = make([]IFAddress, 0, 1)
-	for curaddr := addresses; curaddr != nil; curaddr = (*_Ctype_struct_pcap_addr)(curaddr.next) {
+	for curaddr := addresses; curaddr != nil; curaddr = (*C.struct_pcap_addr)(curaddr.next) {
 		if curaddr.addr == nil {
 			continue
 		}

--- a/pcap_test.go
+++ b/pcap_test.go
@@ -38,6 +38,11 @@ func testPcapHandle(t *testing.T, newHandle pcapNewHandleFunc) {
 		pkt.Decode()
 		t.Logf("Packet:%s dataLen:%d", pkt, len(pkt.Payload))
 		pktsRecvd += 1
+		if pktsRecvd >= numPkts {
+			// some platforms ignore read timeout:
+			// https://github.com/the-tcpdump-group/libpcap/issues/550
+			break
+		}
 	}
 
 	if pktsRecvd != numPkts {
@@ -95,6 +100,11 @@ func TestPcapDump(t *testing.T) {
 		pkt.Decode()
 		t.Logf("Packet:%s dataLen:%d", pkt, len(pkt.Payload))
 		pktsRecvd += 1
+		if pktsRecvd >= numPkts {
+			// some platforms ignore read timeout:
+			// https://github.com/the-tcpdump-group/libpcap/issues/550
+			break
+		}
 	}
 	newh.Close()
 
@@ -106,7 +116,7 @@ func TestPcapDump(t *testing.T) {
 
 	err = os.Remove(ofile)
 	if err != nil {
-		t.Fatalf("Failed to remote pcap file", err)
+		t.Fatalf("Failed to remote pcap file: %s", err)
 	}
 
 	return

--- a/tools/tcpdump/tcpdump.go
+++ b/tools/tcpdump/tcpdump.go
@@ -59,7 +59,7 @@ func main() {
 
 	h, err := pcap.OpenLive(*device, int32(*snaplen), true, 500)
 	if h == nil {
-		fmt.Fprintf(os.Stderr, "tcpdump:", err)
+		fmt.Fprintf(os.Stderr, "tcpdump: %s", err)
 		return
 	}
 	defer h.Close()
@@ -148,7 +148,7 @@ func Dumpline(addr uint32, line []byte) {
 	fmt.Print("  ")
 	for i = 0; i < 16 && i < uint16(len(line)); i++ {
 		if line[i] >= 32 && line[i] <= 126 {
-			fmt.Println("%c", line[i])
+			fmt.Printf("%c\n", line[i])
 		} else {
 			fmt.Print(".")
 		}


### PR DESCRIPTION
- e.g. 'identifier "_Ctype_struct_pcap_stat" may conflict with
  identifiers generated by cgo' and 'Sprintf call needs 2 args but has 3
  args'
- also adds a 'break' in tests since pcap Next() seems to ignore read
  timeout on my system after all packets have been read (Linux)
  - https://github.com/the-tcpdump-group/libpcap/issues/550