### PR TITLE
Allow to compile pcap filters to BPF

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/miekg/pcap
 
 go 1.14
+
+require golang.org/x/net v0.0.0-20220617184016-355a448f1bc9

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,8 @@
+golang.org/x/net v0.0.0-20220617184016-355a448f1bc9 h1:Yqz/iviulwKwAREEeUd3nbBFn0XuyJqkoft2IlrvOhc=
+golang.org/x/net v0.0.0-20220617184016-355a448f1bc9/go.mod h1:XRhObCWvk6IyKnWLug+ECip1KBveYUHfp+8e9klMJ9c=
+golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a h1:dGzPydgVsqGcTRVwiLJ1jVbufYwmzD3LfVPLKsKg+0k=
+golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
+golang.org/x/text v0.3.7/go.mod h1:u+2+/6zg+i71rQMx5EYifcz6MCKuco9NR6JIITiCfzQ=
+golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=

--- a/pcap_test.go
+++ b/pcap_test.go
@@ -60,6 +60,27 @@ func TestPcapOpenLive(t *testing.T) {
 	testPcapHandle(t, pcapOpenLive)
 }
 
+func TestPcapFilterCompile(t *testing.T) {
+	h, err := OpenDead(LINKTYPE_ETHERNET, 65535)
+	if h == nil || err != nil {
+		if h != nil {
+			h.Close()
+		}
+		t.Fatalf("Failed to create/init pcap handle err: %s", err)
+	}
+
+	filter := "udp port 53"
+	insns, err := h.Compile(filter)
+	if err != nil {
+		t.Errorf("Failed to compile filter expression: %s", err)
+	}
+	if len(insns) == 0 {
+		t.Error("Compiled filter has no instructions")
+	}
+
+	h.Close()
+}
+
 func TestPcapDump(t *testing.T) {
 	port := 54321
 	h, err := pcapOpenLive("lo", fmt.Sprintf("udp dst port %d", port), 2000)


### PR DESCRIPTION
libpcap has a filter language (`pcap-filter(7)`) that it can compile into BPF instructions. With this PR, `pcap_compile(3)` gets exposed. Additionally, `pcap_open_dead(3)` gets exposed, which allows to open a fake `Pcap` that can be used to compile the filters without having to open a real interface of the system. 

This allows to compile pcap filters to BPF instructions. See the added test for an usage example.